### PR TITLE
Add darwin arm64 artifact

### DIFF
--- a/.github/workflows/build_release_darwin_arm64.yml
+++ b/.github/workflows/build_release_darwin_arm64.yml
@@ -1,0 +1,1 @@
+# Don't know what to do here but generate the darwin artifact but with arm64

--- a/.github/workflows/build_release_darwin_arm64.yml
+++ b/.github/workflows/build_release_darwin_arm64.yml
@@ -1,1 +1,1 @@
-# Don't know what to do here but generate the darwin artifact but with arm64
+# Don't know what to do here but generate the darwin artifact similar to the other workflow but for arm64


### PR DESCRIPTION
I'm using your great fork and it would be awesome to have darwin arm64 added to the release artifacts. Currently I've installed global dependencies locally to build it when installing dependencies and it would be great to get rid of then.
It seems to be there for the original project but not this fork.

`faiss-napi-v0.10.1-napi-v8-darwin-arm64.tar.gz`